### PR TITLE
Move logo to navigation

### DIFF
--- a/index.html
+++ b/index.html
@@ -23,13 +23,13 @@
             scroll-behavior: smooth;
         }
         .logo-container img {
-            height: 400px; /* Much larger size */
+            height: 60px;
             width: auto;
             max-width: 100%;
         }
         @media (max-width: 768px) {
             .logo-container img {
-                height: 300px;
+                height: 40px;
             }
         }
     </style>
@@ -57,25 +57,20 @@
     <!-- Navigation -->
     <nav class="bg-white shadow-lg">
         <div class="max-w-6xl mx-auto px-4">
-            <div class="flex justify-end items-center h-16">
+            <div class="flex justify-end items-center h-16 space-x-4">
                 <div class="flex space-x-8">
                     <a href="#services" class="text-gray-600 hover:text-[#4A3425] text-lg">Services</a>
                     <a href="#expertise" class="text-gray-600 hover:text-[#4A3425] text-lg">Expertise</a>
                     <a href="#process" class="text-gray-600 hover:text-[#4A3425] text-lg">Process</a>
                     <a href="#contact" class="text-gray-600 hover:text-[#4A3425] text-lg">Contact</a>
                 </div>
+                <div class="logo-container">
+                    <img src="assets/logo-color.png" alt="Olson Analytics LLC logo">
+                </div>
             </div>
         </div>
     </nav>
 
-    <!-- Logo Section -->
-    <div class="bg-white py-20">
-        <div class="max-w-6xl mx-auto px-4">
-            <div class="flex justify-center items-center logo-container">
-                <img src="assets/logo-color.png" alt="Olson Analytics LLC logo">
-            </div>
-        </div>
-    </div>
 
     <!-- Hero Section -->
     <div class="brand-bg py-20">


### PR DESCRIPTION
## Summary
- tweak logo styles for a smaller size
- relocate the logo to the navigation bar and remove the old logo section

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6886b25158e88326aa8fac474a263a20